### PR TITLE
Updated README.md by changing DiffusionPipeline to StableDiffusionPipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ accelerate launch train_svdiff.py \
 ### Inference
 
 ```python
-from diffusers import DiffusionPipeline, DPMSolverMultistepScheduler
+from diffusers import StableDiffusionPipeline, DPMSolverMultistepScheduler
 import torch
 
 from svdiff_pytorch import load_unet_for_svdiff, load_text_encoder_for_svdiff


### PR DESCRIPTION
Updated ```DiffusionPipeline``` to ```StableDiffusionPipeline``` in [Inference](https://github.com/mkshing/svdiff-pytorch?tab=readme-ov-file#inference).